### PR TITLE
Give the lib a friendlier public API.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 
 [[package]]
 name = "nightshift"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 categories = ["command-line-utilities", "os::macos-apis"]
 description = "A CLI for configuring 'Night Shift' on macOS 🌕🌖🌗🌘🌑"
 repository = "https://github.com/smudge/nightshift"
+readme = "README.md"
 license = "MIT"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nightshift"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["smudge <nathan@ngriffith.com>"]
 edition = "2018"
 categories = ["command-line-utilities", "os::macos-apis"]

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ nightshift temp 70
 In addition to a CLI, `nightshift` can be pulled-in as a dependency for other Rust crates:
 
 ```
-nightshift = "0.0.1"
+nightshift = "0.0.2"
 ```
 
 Here's an example `fn` that toggles Night Shift off,

--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ use nightshift::NightShift;
 
 fn main() {
     let night_shift = NightShift::new();
-    night_shift.enable(false).unwrap();
-    night_shift.set_temp("70".to_string()).unwrap();
-    night_shift.enable(true).unwrap();
+    night_shift.off().unwrap();
+    night_shift.set_temp(70).unwrap();
+    night_shift.on().unwrap();
 }
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,23 +22,30 @@ impl NightShift {
         NightShift { client }
     }
 
-    pub fn enable(&self, enabled: bool) -> Result<(), String> {
-        let result: BOOL = unsafe { msg_send![*self.client, setEnabled: (enabled as BOOL)] };
+    pub fn on(&self) -> Result<(), String> {
+        self.toggle(true)
+    }
+
+    pub fn off(&self) -> Result<(), String> {
+        self.toggle(false)
+    }
+
+    pub fn toggle(&self, on: bool) -> Result<(), String> {
+        let result: BOOL = unsafe { msg_send![*self.client, setEnabled: (on as BOOL)] };
         if result == (true as BOOL) {
             Ok(())
         } else {
-            Err(format!("Failed to turn Night Shift {}", on_or_off(enabled)))
+            Err(format!("Failed to turn Night Shift {}", on_or_off(on)))
         }
     }
 
-    pub fn set_temp(&self, temp: &String) -> Result<(), String> {
-        let temp = match temp.parse::<f32>() {
-            Ok(v) => v / 100.0,
-            Err(_) => {
-                return Err("Color temperature must be a number from 0 to 100.".to_string());
-            }
-        };
-        let result: BOOL = unsafe { msg_send![*self.client, setStrength:temp commit:YES] };
+    pub fn set_temp(&self, temp: i32) -> Result<(), String> {
+        if temp < 0 || temp > 100 {
+            return Err("Color temperature must be a number from 0 to 100.".to_string());
+        }
+
+        let strength = temp as f32 / 100.0;
+        let result: BOOL = unsafe { msg_send![*self.client, setStrength:strength commit:YES] };
 
         if result == (true as BOOL) {
             Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,11 +26,12 @@ fn main() {
 
     let night_shift = NightShift::new();
     if args.len() == 2 && args[1] == "on" {
-        night_shift.enable(true).unwrap_or_else(|e| error(e));
+        night_shift.on().unwrap_or_else(|e| error(e));
     } else if args.len() == 2 && args[1] == "off" {
-        night_shift.enable(false).unwrap_or_else(|e| error(e));
+        night_shift.off().unwrap_or_else(|e| error(e));
     } else if args.len() == 3 && args[1] == "temp" {
-        night_shift.set_temp(&args[2]).unwrap_or_else(|e| error(e));
+        let temp = args[2].parse().unwrap_or(-1);
+        night_shift.set_temp(temp).unwrap_or_else(|e| error(e));
     } else {
         print_usage(&args[0]);
     }
@@ -38,5 +39,5 @@ fn main() {
 
 fn error(text: String) {
     eprintln!("{}", text);
-    exit(1);
+    exit(1)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,8 +11,8 @@ fn print_usage(program: &String) {
     println!("{}\n", env!("CARGO_PKG_DESCRIPTION"));
     println!("Usage:\n  {} [command]\n", program);
     println!("Available Commands:");
-    println!("  on                  Turns Night Shift on (until tomorrow/sunrise)");
-    println!("  off                 Turns Night Shift off");
+    println!("  on                  Turn Night Shift on (until tomorrow/sunrise)");
+    println!("  off                 Turn Night Shift off");
     println!("  temp [0-100]        Set color temperature preference (does not affect on/off)");
 }
 


### PR DESCRIPTION
Rather than this (named after the internal function, not the external use case):

```rust
pub fn enable(&self, enabled: bool) -> Result<(), String>
```

We now have:

```rust
pub fn on(&self) -> Result<(), String> 
pub fn off(&self) -> Result<(), String>
pub fn toggle(&self, on: bool) -> Result<(), String>
```

Also `set_temp` now accepts an integer instead of a string, since only the CLI should care about parsing the input strings.