### PR TITLE
Warnings, resiliency, and bump version to 0.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 
 [[package]]
 name = "nightshift"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nightshift"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["smudge <nathan@ngriffith.com>"]
 edition = "2018"
 categories = ["command-line-utilities", "os::macos-apis"]

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ nightshift temp 70
 In addition to a CLI, `nightshift` can be pulled-in as a dependency for other Rust crates:
 
 ```
-nightshift = "0.0.2"
+nightshift = "0.0.3"
 ```
 
 Here's an example `fn` that toggles Night Shift off,

--- a/src/ffi/status.rs
+++ b/src/ffi/status.rs
@@ -18,13 +18,13 @@ struct Schedule {
 #[derive(Default)]
 #[repr(C)]
 pub struct InnerStatus {
-    active: BOOL,
+    _active: BOOL,
     enabled: BOOL,
-    sun_schedule_permitted: BOOL,
+    _sun_schedule_permitted: BOOL,
     mode: c_int,
     schedule: Schedule,
-    disable_flags: u64,
-    available: BOOL,
+    _disable_flags: u64,
+    _available: BOOL,
 }
 
 #[derive(Default)]
@@ -41,28 +41,12 @@ impl BlueLightStatus {
         BlueLightStatus { inner }
     }
 
-    pub fn active(&self) -> bool {
-        self.inner.active == YES
-    }
-
     pub fn enabled(&self) -> bool {
         self.inner.enabled == YES
     }
 
-    pub fn sun_schedule_permitted(&self) -> bool {
-        self.inner.sun_schedule_permitted == YES
-    }
-
     pub fn mode(&self) -> i32 {
         self.inner.mode as i32
-    }
-
-    pub fn disable_flags(&self) -> u64 {
-        self.inner.disable_flags
-    }
-
-    pub fn available(&self) -> bool {
-        self.inner.available == YES
     }
 
     pub fn from_time(&self) -> String {

--- a/src/ffi/status.rs
+++ b/src/ffi/status.rs
@@ -1,6 +1,8 @@
 use objc::runtime::{BOOL, YES};
 use std::os::raw::c_int;
 
+mod padding;
+
 #[derive(Default)]
 #[repr(C)]
 struct Time {
@@ -25,6 +27,7 @@ pub struct InnerStatus {
     schedule: Schedule,
     _disable_flags: u64,
     _available: BOOL,
+    padding: padding::Padding,
 }
 
 #[derive(Default)]
@@ -38,6 +41,13 @@ impl BlueLightStatus {
     }
 
     pub fn new(inner: InnerStatus) -> BlueLightStatus {
+        if !inner.padding.is_empty() {
+            eprintln!(
+                "======== \
+                \nWarning: Your version of macOS may be new, resulting in unexpected behavior. \
+                \n========"
+            )
+        }
         BlueLightStatus { inner }
     }
 

--- a/src/ffi/status/padding.rs
+++ b/src/ffi/status/padding.rs
@@ -1,0 +1,19 @@
+const BYTES: usize = 20;
+
+/// Padding ... with some bytes
+/// Helps avoid overflowing a C-struct
+pub struct Padding {
+    bytes: [u8; BYTES],
+}
+
+impl Default for Padding {
+    fn default() -> Padding {
+        Padding { bytes: [0; BYTES] }
+    }
+}
+
+impl Padding {
+    pub fn is_empty(&self) -> bool {
+        self.bytes.iter().map(|i| *i as u64).sum::<u64>() != 0
+    }
+}


### PR DESCRIPTION
- [X] Clear out warnings about unused methods.
- [X] Add some small amount of resiliency to breaking changes on newer macOS versions - if more data is written to the "status" struct than is expected, we output a loud "WARNING" to stderr. At the very least, this will prompt someone to post an issue and help us know when to update the struct.