### PR TITLE
feat: toggle nightlight by default instead of printing the help menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Toggle on or off based on current status:
 
 ```
 nightlight toggle
+nightlight <noargs>
 ```
 
 #### Controlling the Temperature:

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Toggle on or off based on current status:
 
 ```
 nightlight toggle
-nightlight <noargs>
+nightlight <none>
 ```
 
 #### Controlling the Temperature:

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,9 @@ fn main() {
     let args: Vec<String> = args().collect();
 
     let client = NightLight::new();
-    if args.len() == 2 && args[1] == "on" {
+    if args.len() == 1 {
+        toggle(client).unwrap_or_else(|e| error(e));
+    } else if args.len() == 2 && args[1] == "on" {
         client.on().unwrap_or_else(|e| error(e));
     } else if args.len() == 2 && args[1] == "off" {
         client.off().unwrap_or_else(|e| error(e));
@@ -86,7 +88,7 @@ fn main() {
     } else if args.len() == 2 && args[1] == "help" {
         print_usage(&args[0]);
     } else {
-        toggle(client).unwrap_or_else(|e| error(e));
+        print_usage(&args[0]);
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ fn print_usage(program: &String) {
     println!("  off                      Turn Night Shift off (until scheduled start)");
     println!("  status                   View current on/off status");
     println!("  toggle                   Toggle on or off based on current status");
+    println!("  <noargs>                 Toggle on or off based on current status");
     println!("\ncolor temperature:");
     println!("  temp                     View temperature preference");
     println!("  temp <0-100|3500K-6500K> Set temperature preference (does not affect on/off)");
@@ -20,6 +21,7 @@ fn print_usage(program: &String) {
     println!("  schedule start           Start schedule from sunset to sunrise");
     println!("  schedule <from> <to>     Start a custom schedule (12 or 24-hour time format)");
     println!("  schedule stop            Stop the current schedule");
+    println!("  help                     Print this help menu");
 }
 
 fn print_status(client: NightLight) -> Result<(), String> {
@@ -48,11 +50,6 @@ fn toggle(client: NightLight) -> Result<(), String> {
 
 fn main() {
     let args: Vec<String> = args().collect();
-
-    if args.len() < 2 {
-        print_usage(&args[0]);
-        exit(1);
-    }
 
     let client = NightLight::new();
     if args.len() == 2 && args[1] == "on" {
@@ -86,8 +83,10 @@ fn main() {
     } else if args.len() == 3 && args[1] == "temp" {
         let temp = temp_userinput(args[2].clone());
         client.set_temp(temp).unwrap_or_else(|e| error(e));
-    } else {
+    } else if args.len() == 2 && args[1] == "help" {
         print_usage(&args[0]);
+    } else {
+        toggle(client).unwrap_or_else(|e| error(e));
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ fn print_usage(program: &String) {
     println!("  off                      Turn Night Shift off (until scheduled start)");
     println!("  status                   View current on/off status");
     println!("  toggle                   Toggle on or off based on current status");
-    println!("  <none>                 Toggle on or off based on current status");
+    println!("  <noargs>                 Toggle on or off based on current status");
     println!("\ncolor temperature:");
     println!("  temp                     View temperature preference");
     println!("  temp <0-100|3500K-6500K> Set temperature preference (does not affect on/off)");

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ fn print_usage(program: &String) {
     println!("  off                      Turn Night Shift off (until scheduled start)");
     println!("  status                   View current on/off status");
     println!("  toggle                   Toggle on or off based on current status");
-    println!("  <noargs>                 Toggle on or off based on current status");
+    println!("  <none>                 Toggle on or off based on current status");
     println!("\ncolor temperature:");
     println!("  temp                     View temperature preference");
     println!("  temp <0-100|3500K-6500K> Set temperature preference (does not affect on/off)");


### PR DESCRIPTION
Changes behavior of the tool.
- `nightlight` now toggles nightshift instead of displaying help menu
- `nightlight help` now toggles help menu instead 

Inspired by https://github.com/sindresorhus/dark-mode?tab=readme-ov-file#usage